### PR TITLE
build: add router base path configurable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm run lint
 
       - name: Generate ⚙️
+        env:
+          BASE_PATH: ${{ secrets.BASE_PATH }}
         run: npm run generate
 
       - name: Deploy 🚀

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: ci
 
-on:
-  push:
-    branches-ignore:
-      - main
-  pull_request:
+on: [pull_request]
 
 jobs:
   ci:

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -2,6 +2,9 @@ export default {
   // Target: https://go.nuxtjs.dev/config-target
   target: 'static',
   ssr: false,
+  router: {
+    base: process.env.BASE_PATH || '/',
+  },
 
   // Global page headers: https://go.nuxtjs.dev/config-head
   head: {


### PR DESCRIPTION
## ✍️ Description

This adds a new environment variable called `BASE_PATH` to make the nuxt router configurable. Since we don't have a custom domain in this repository we need to use the repository as a base path as explained in https://nuxtjs.org/docs/2.x/deployment/github-pages/