### PR TITLE
chore: remove 'by' in the floating cards.

### DIFF
--- a/components/FloatingCard.vue
+++ b/components/FloatingCard.vue
@@ -12,7 +12,7 @@
     </div>
     <div class="card__content">
       <h4>{{ project.name }}</h4>
-      <p>by {{ project.speaker }} ({{ project.handler }})</p>
+      <p>{{ project.speaker }} ({{ project.handler }})</p>
     </div>
   </div>
 </template>


### PR DESCRIPTION
### ✍🏻   Description
Remove 'by' in the floating cards.

### 📷  Screenshot
![Screenshot 2021-04-05 at 17 38 21](https://user-images.githubusercontent.com/39853718/113592658-b8a22800-9635-11eb-8927-51e986d5d759.png)

### 🔗  URL
- [Task](https://app.clickup.com/t/gn8zac)