### PR TITLE
feat: move Header to layout

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,0 +1,27 @@
+<template>
+  <header>
+    <GitHub aria-hidden="true" role="presentation" />
+  </header>
+</template>
+
+<script>
+import GitHub from '~/assets/svg/github.svg?inline'
+
+export default {
+  components: {
+    GitHub,
+  },
+}
+</script>
+
+<style lang="scss" scoped>
+header {
+  @include section();
+
+  position: relative;
+  margin-top: 40px;
+  @media screen and (min-width: $screen-ipad) {
+    margin-top: 80px;
+  }
+}
+</style>

--- a/components/Hero.vue
+++ b/components/Hero.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <div class="hero">
-      <GitHub aria-hidden="true" role="presentation" />
       <h1 class="hero__title">{{ content.title }}</h1>
       <p class="hero__subtitle">{{ content.subtitle }}</p>
     </div>
@@ -9,12 +8,7 @@
 </template>
 
 <script>
-import GitHub from '~/assets/svg/github.svg?inline'
-
 export default {
-  components: {
-    GitHub,
-  },
   props: {
     content: {
       type: Object,
@@ -26,12 +20,6 @@ export default {
 
 <style lang="scss" scoped>
 .hero {
-  position: relative;
-  margin-top: 40px;
-  @media screen and (min-width: $screen-ipad) {
-    margin-top: 80px;
-  }
-
   &__title {
     max-width: 480px;
     margin-top: 40px;

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,3 +1,7 @@
 <template>
-  <Nuxt />
+  <div>
+    <Nuxt />
+    <Footer />
+    <DecorativeGlows />
+  </div>
 </template>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <Header />
     <Nuxt />
     <Footer />
     <DecorativeGlows />

--- a/layouts/error.vue
+++ b/layouts/error.vue
@@ -4,8 +4,6 @@
     <h1 class="error__title">Oh god!</h1>
     <p>We can't find the page you're looking for, sorry.</p>
     <CommonLink button to="/">Back to Homepage</CommonLink>
-    <Footer />
-    <DecorativeGlows />
   </main>
 </template>
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -11,9 +11,7 @@
         </CommonLink>
       </div>
       <Projects :content="projects" />
-      <Footer />
     </section>
-    <DecorativeGlows />
   </main>
 </template>
 <script>


### PR DESCRIPTION
### ✍🏻 Description
We had the header (the GitHub logo) as part of the Hero, which was causing that it wasn't displayed in other pages (just the 404 right now). This PR is to create the header in a separated component and include it in the default layout, so it's displayed in all pages.

It also moves footer and decoration glows to the default layout for the same reason.

### 📸 Screenshots
<img width="1255" alt="Screenshot 2021-04-07 at 10 24 01" src="https://user-images.githubusercontent.com/39853718/113834658-6115d080-978b-11eb-86db-9760946795ae.png">

### 🔗 URLs
- [Task](https://app.clickup.com/t/gq78a6)