### PR TITLE
fix: calendar not clickable because of cards

### DIFF
--- a/components/FloatingCard.vue
+++ b/components/FloatingCard.vue
@@ -47,6 +47,7 @@ export default {
   border: 1px solid var(--border-floating-card);
   border-radius: 8px;
   box-shadow: 0 0 32px 0 var(--bs-floating-card);
+  pointer-events: auto;
 
   @supports (
     (-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))

--- a/components/FloatingCards.vue
+++ b/components/FloatingCards.vue
@@ -103,6 +103,7 @@ export default {
     width: 100%;
     height: 500px;
     transition: top linear;
+    pointer-events: none;
     will-change: top;
     .card {
       position: absolute;


### PR DESCRIPTION
The floating cards' wrapper was preventing the calendar event to be clickable. This PR makes just the actual cards clickable.

[Task](https://app.clickup.com/t/gx4ya0)