### PR TITLE
feat: limit floating cards to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 ### Step 1
 
-Go to `content/home.json` file. To add a new maintainer just add to the `maintainers` array a new `maintainer` object. To add a new project, find the maintainer in the array and just add a new `project` object to the projects array.
+Go to `content/home.json` file.
+
+To add a new maintainer just add to the `maintainers` array a new `maintainer` object providing the speaker name, their GitHub profile handler and a list with the projects they maintain.
+
+To add a new project, find the maintainer in the array and just add a new `project` object to the projects array, providing the project name and GitHub repo URL for each project.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,4 +1,39 @@
-# global-maintainers-summit
+# Global Maintainers Summit
+
+## Add new maintainers or projects to current maintainers
+
+### Step 1
+
+Go to `content/home.json` file. To add a new maintainer just add to the `maintainers` array a new `maintainer` object. To add a new project, find the maintainer in the array and just add a new `project` object to the projects array.
+
+```json
+{
+  "speaker": "Siân Griffin",
+  "handler": "sgrif",
+  "projects": [
+    {
+      "name": "Diesel",
+      "url": "https://github.com/diesel-rs/diesel"
+    }
+  ]
+}
+```
+
+### Step 2
+
+For each new **project** added, there should be the correspondent logo in `assets/img/badges` in order to be able to render the project in the floating cards.
+
+The logo filename must be as follows:
+
+- One file with normal quality named `logo_[project-name].png`
+- Another bigger file with better quality named `logo_[project-name]@2x.png`
+
+E.g. for the previous json, we should add the two following files:
+
+- `logo_diesel.png`
+- `logo_diesel@2x.png`
+
+---
 
 ## Build Setup
 

--- a/components/FloatingCards.vue
+++ b/components/FloatingCards.vue
@@ -26,12 +26,15 @@ export default {
   },
   computed: {
     projects() {
-      return this.maintainers?.flatMap((maintainer) =>
-        maintainer.projects.map((project) => ({
-          ...project,
-          speaker: maintainer.speaker,
-        }))
-      )
+      const TOTAL_CARDS = 8
+      return this.maintainers
+        ?.flatMap((maintainer) =>
+          maintainer.projects.map((project) => ({
+            ...project,
+            speaker: maintainer.speaker,
+          }))
+        )
+        .slice(0, TOTAL_CARDS)
     },
   },
   mounted() {


### PR DESCRIPTION
## ✍️ Description
- Limit projects rendered in card to 8 which are the number of cards designed.
- Update Readme with instructions on how to add new maintainers and/or projects.

Pending to do in a future PR: implement a strategy to choose which projects are displayed in the floating cards (after we discuss it and come to an agreement).

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 🔗 Relevant URLs
* [Task](https://app.clickup.com/t/gx8cua)