### PR TITLE
fix: move floating cards a bit closer to top

### DIFF
--- a/components/FloatingCards.vue
+++ b/components/FloatingCards.vue
@@ -91,7 +91,7 @@ export default {
   display: none;
   @media screen and (min-width: $screen-xl) {
     position: absolute;
-    top: 380px;
+    top: 310px;
     right: 0;
     left: 0;
     display: block;
@@ -127,7 +127,7 @@ export default {
       }
       &:nth-child(4) {
         // Homebrew
-        top: 350px;
+        top: 370px;
         right: calc(100vw * 0.075);
       }
       &:nth-child(5) {


### PR DESCRIPTION
## ✍️ Description
Move floating cards a bit closer to top.

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots
![Screenshot 2021-04-12 at 19 12 01](https://user-images.githubusercontent.com/39853718/114434145-f74e5a00-9bc2-11eb-81d3-47384c1813a9.png)

## 🔗 Relevant URLs
* [Task](url)