### PR TITLE
fix: use UTC dates to avoid problems with timezones

### DIFF
--- a/components/Lead.vue
+++ b/components/Lead.vue
@@ -31,15 +31,15 @@ export default {
   },
   computed: {
     dates() {
-      const startDay = this.startDate.getDate()
+      const startDay = this.startDate.getUTCDate()
       const startMonth = this.startDate.toLocaleDateString(this.locale, {
         month: 'long',
       })
-      const endDay = this.endDate.getDate()
+      const endDay = this.endDate.getUTCDate()
       const endMonth = this.endDate.toLocaleDateString(this.locale, {
         month: 'long',
       })
-      const year = this.startDate.getFullYear()
+      const year = this.startDate.getUTCFullYear()
 
       return startMonth === endMonth
         ? `${startMonth} ${startDay}-${endDay}, ${year}`
@@ -62,7 +62,7 @@ export default {
     },
     nextDay(date) {
       const nextDate = new Date(date)
-      return new Date(nextDate.setDate(nextDate.getDate() + 1))
+      return new Date(nextDate.setDate(nextDate.getUTCDate() + 1))
     },
   },
 }


### PR DESCRIPTION
## ✍️ Description

This resolves the problem about rendering the wrong date when the user was in a different timezone. (i.e. when I was in the Canada timezone I saw the day before the date).
