### PR TITLE
fix: remove duplicated speaker

### DIFF
--- a/content/home.json
+++ b/content/home.json
@@ -122,16 +122,6 @@
         }
       ]
     },
-     {
-      "speaker": "Ifiok Jr.",
-      "handler": "ifiokjr",
-      "projects": [
-        {
-          "name": "Remirror",
-          "url": "https://github.com/remirror"
-        }
-      ]
-    },
     {
       "speaker": "Chrissy LeMaire",
       "handler": "potatoqualitee",

--- a/cypress/integration/home.spec.js
+++ b/cypress/integration/home.spec.js
@@ -19,6 +19,21 @@ describe('Home', () => {
     })
   })
 
+  it('There are no duplicated speakers in the Maintainers list', () => {
+    cy.visit('/')
+    cy.get('[data-cy=speaker]').then(($speakers) => {
+      let speakers = []
+
+      $speakers.each((_, speakerElement) => {
+        speakers = [...speakers, speakerElement.innerText]
+      })
+
+      const uniqueSpeakers = new Set(speakers).size
+
+      expect(uniqueSpeakers).to.equal(speakers.length)
+    })
+  })
+
   it('Maintainers are clickable', () => {
     cy.visit('/')
     cy.get('[data-cy=speaker]').each(($link) => {


### PR DESCRIPTION
## ✍️ Description
Removes duplicated speaker and adds e2e to check there are no duplicated speakers in the maintainers list.

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [x] Add documentation and tests if needed.

## 📸 Screenshots
| | Screenshot |
-----------|:------------:|
| Before |![Screenshot 2021-04-15 at 11 50 03](https://user-images.githubusercontent.com/39853718/114850336-f1ce5b00-9de0-11eb-8702-669c2dfcc056.png)|
| After |![Screenshot 2021-04-15 at 11 49 37](https://user-images.githubusercontent.com/39853718/114850301-e8dd8980-9de0-11eb-85ad-e742d2d1b18c.png)|
| Test |![Screenshot 2021-04-15 at 11 48 32](https://user-images.githubusercontent.com/39853718/114850276-e24f1200-9de0-11eb-933d-c05e8575f9f2.png)|

## 🔗 Relevant URLs
- [Task](https://app.clickup.com/t/h91hfr)